### PR TITLE
Add join tests and refactor agent interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ unit:
 
 cover:
 	@mkdir -p _dist
-	@go test ./... -coverprofile=_dist/coverage.out -tags integration
+	@go test -coverprofile=_dist/coverage.out -v
 	@go tool cover -html=_dist/coverage.out -o _dist/coverage.html
 
 gen:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cluster coordinator for Dragonboat.
 [![Go Report Card](https://goreportcard.com/badge/github.com/logbn/zongzi?4)](https://goreportcard.com/report/github.com/logbn/zongzi)
 [![Go Coverage](https://github.com/logbn/zongzi/wiki/coverage.svg)](https://raw.githack.com/wiki/logbn/zongzi/coverage.html)
 
-The primary goal of this package is to completely wrap Dragonboat behind a facade that presents a simpler interface.
+The goal of this package is to wrap Dragonboat behind a facade that presents a simpler interface.
 
 - Cluster State Registry
   - Prime shard (shardID: 0)

--- a/_example/controller/controller.go
+++ b/_example/controller/controller.go
@@ -105,13 +105,13 @@ func (c *controller) start() {
 						return true
 					})
 					index = state.Index()
-				})
+				}, true)
 				if index != prevIndex {
 					c.agent.Read(func(state zongzi.State) {
 						buf := bytes.NewBufferString("")
 						state.Save(buf)
 						log.Print(buf.String())
-					})
+					}, true)
 				}
 			case <-ctx.Done():
 				c.mutex.Lock()

--- a/agent_integration_test.go
+++ b/agent_integration_test.go
@@ -14,45 +14,44 @@ import (
 
 func TestAgent(t *testing.T) {
 	basedir := `/tmp/zongzi-test`
-	agents := make([]*Agent, 3)
-	t.Run(`start`, func(t *testing.T) {
-		os.RemoveAll(basedir)
-		var (
-			apiAddr    = []string{`127.0.0.1:17101`, `127.0.0.1:17111`, `127.0.0.1:17121`}
-			gossipAddr = []string{`127.0.0.1:17102`, `127.0.0.1:17112`, `127.0.0.1:17122`}
-			raftAddr   = []string{`127.0.0.1:17103`, `127.0.0.1:17113`, `127.0.0.1:17123`}
-		)
-		for i := range agents {
-			a, err := NewAgent(`test001`, apiAddr,
+	agents := []*Agent{}
+	defer func() {
+		for _, a := range agents {
+			a.Stop()
+		}
+	}()
+	os.RemoveAll(basedir)
+	run := func(t *testing.T, peers, apiAddr, gossipAddr, raftAddr []string) {
+		for i := range apiAddr {
+			a, err := NewAgent(`test001`, peers,
 				WithApiAddress(apiAddr[i]),
 				WithGossipAddress(gossipAddr[i]),
 				WithHostConfig(HostConfig{
-					WALDir:         fmt.Sprintf(basedir+`/agent-%d/wal`, i),
-					NodeHostDir:    fmt.Sprintf(basedir+`/agent-%d/raft`, i),
+					WALDir:         fmt.Sprintf(basedir+`/agent-%d/wal`, len(agents)),
+					NodeHostDir:    fmt.Sprintf(basedir+`/agent-%d/raft`, len(agents)),
 					RaftAddress:    raftAddr[i],
-					RTTMillisecond: 100,
+					RTTMillisecond: 10,
 				}))
 			require.Nil(t, err)
 			go func(a *Agent) {
 				err := a.Start()
-				assert.Nil(t, err)
+				assert.Nil(t, err, `%+v`, err)
 			}(a)
-			defer a.Stop()
-			agents[i] = a
+			agents = append(agents, a)
 		}
 		var good bool
 		// 10 seconds to start the cluster.
 		for i := 0; i < 100; i++ {
 			good = true
 			for j := range agents {
-				good = good && agents[j].GetStatus() == AgentStatus_Ready
+				good = good && agents[j].Status() == AgentStatus_Ready
 			}
 			if good {
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		assert.True(t, good, `%v %v %v`, agents[0].GetStatus(), agents[1].GetStatus(), agents[2].GetStatus())
+		assert.True(t, good, `%+v`, agents)
 		// 10 seconds for all host controllers to complete their first run.
 		for i := 0; i < 100; i++ {
 			good = true
@@ -64,6 +63,49 @@ func TestAgent(t *testing.T) {
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		assert.True(t, good, `%v %v %v`, agents[0].controller.index, agents[1].controller.index, agents[2].controller.index)
+		assert.True(t, good, `%+v`, agents)
+	}
+	peers := []string{`127.0.0.1:17101`, `127.0.0.1:17111`, `127.0.0.1:17121`}
+	t.Run(`start`, func(t *testing.T) {
+		run(t, peers,
+			[]string{`127.0.0.1:17101`, `127.0.0.1:17111`, `127.0.0.1:17121`},
+			[]string{`127.0.0.1:17102`, `127.0.0.1:17112`, `127.0.0.1:17122`},
+			[]string{`127.0.0.1:17103`, `127.0.0.1:17113`, `127.0.0.1:17123`},
+		)
 	})
+	t.Run(`join`, func(t *testing.T) {
+		run(t, peers,
+			[]string{`127.0.0.1:17131`, `127.0.0.1:17141`, `127.0.0.1:17151`},
+			[]string{`127.0.0.1:17132`, `127.0.0.1:17142`, `127.0.0.1:17152`},
+			[]string{`127.0.0.1:17133`, `127.0.0.1:17143`, `127.0.0.1:17153`},
+		)
+		// 5 seconds for all hosts to see themselves with at least one active replica
+		var good bool
+		var replicas []Replica
+		for i := 0; i < 100; i++ {
+			good = true
+			replicas = replicas[:0]
+			for j, a := range agents {
+				agents[j].Read(func(s State) {
+					var replicaCount = 0
+					s.ReplicaIterateByHostID(a.HostID(), func(r Replica) bool {
+						replicas = append(replicas, r)
+						if r.Status == ReplicaStatus_Active {
+							replicaCount++
+						}
+						return true
+					})
+					good = good && replicaCount > 0
+				}, true)
+			}
+			if good {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		assert.True(t, good, `%+v`, replicas)
+	})
+	// Create shard
+	// Add replicas
+	// Assert initialized
 }

--- a/fsm.go
+++ b/fsm.go
@@ -156,10 +156,11 @@ func (fsm *fsm) Update(entry Entry) (Result, error) {
 		case command_action_status_update:
 			replica, ok := state.ReplicaGet(cmd.Replica.ID)
 			if !ok {
-				fsm.log.Warningf("%v: %#v", ErrReplicaNotFound, cmd)
+				fsm.log.Warningf("%v: %#v %#v", ErrReplicaNotFound, cmd, replica)
 				break
 			}
 			replica.Status = cmd.Replica.Status
+			state.replicaPut(replica)
 			entry.Result.Value = 1
 		// Put
 		case command_action_put:

--- a/fsm_state_radix.go
+++ b/fsm_state_radix.go
@@ -230,7 +230,10 @@ func (fsm *fsmStateRadix) ShardIterate(fn func(s Shard) bool) {
 }
 
 func (fsm *fsmStateRadix) ReplicaGet(id uint64) (r Replica, ok bool) {
-	res, _ := fsm.txn.First(`replica`, `id`, id)
+	res, err := fsm.txn.First(`replica`, `id`, id)
+	if err != nil {
+		panic(err)
+	}
 	if res != nil {
 		r = res.(Replica)
 		ok = true

--- a/grpc_server.go
+++ b/grpc_server.go
@@ -33,7 +33,7 @@ func (s *grpcServer) Probe(ctx context.Context, req *internal.ProbeRequest) (res
 
 func (s *grpcServer) Info(ctx context.Context, req *internal.InfoRequest) (res *internal.InfoResponse, err error) {
 	return &internal.InfoResponse{
-		HostId:    s.agent.GetHostID(),
+		HostId:    s.agent.HostID(),
 		ReplicaId: s.agent.replicaConfig.ReplicaID,
 	}, nil
 }
@@ -51,7 +51,7 @@ func (s *grpcServer) Join(ctx context.Context, req *internal.JoinRequest) (res *
 }
 
 func (s *grpcServer) Propose(ctx context.Context, req *internal.Request) (res *internal.Response, err error) {
-	if s.agent.GetStatus() != AgentStatus_Ready {
+	if s.agent.Status() != AgentStatus_Ready {
 		err = ErrAgentNotReady
 		return
 	}

--- a/host_client.go
+++ b/host_client.go
@@ -22,7 +22,7 @@ func newHostClient(host Host, a *Agent) *HostClient {
 }
 
 func (c *HostClient) Ping(ctx context.Context) (err error) {
-	if c.hostID == c.agent.GetHostID() {
+	if c.hostID == c.agent.HostID() {
 		return
 	}
 	_, err = c.agent.grpcClientPool.get(c.hostApiAddress).Ping(ctx, &internal.PingRequest{})

--- a/replica_client.go
+++ b/replica_client.go
@@ -40,7 +40,7 @@ func (c *ReplicaClient) Propose(ctx context.Context, cmd []byte, linear bool) (v
 		c.agent.log.Warningf(`%v`, ErrNotifyCommitDisabled)
 	}
 	var res *internal.Response
-	if c.hostID == c.agent.GetHostID() {
+	if c.hostID == c.agent.HostID() {
 		res, err = c.agent.grpcServer.Propose(ctx, &internal.Request{
 			ShardId: c.shardID,
 			Linear:  linear,
@@ -75,7 +75,7 @@ func (c *ReplicaClient) Propose(ctx context.Context, cmd []byte, linear bool) (v
 //	true  - if you are willing to pay the extra latency for a highly consistent read.
 func (c *ReplicaClient) Query(ctx context.Context, query []byte, linear bool) (value uint64, data []byte, err error) {
 	var res *internal.Response
-	if c.hostID == c.agent.GetHostID() {
+	if c.hostID == c.agent.HostID() {
 		res, err = c.agent.grpcServer.Query(ctx, &internal.Request{
 			ShardId: c.shardID,
 			Linear:  linear,

--- a/util.go
+++ b/util.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	minReplicas  = 3
-	raftTimeout  = time.Second
+	raftTimeout  = 3 * time.Second
 	joinTimeout  = 5 * time.Second
 	projectName  = "zongzi"
 	shardUri     = "github.com/logbn/zongzi/prime"


### PR DESCRIPTION
- Rename `(*Agent).GetHostID` to `(*Agent).HostID`
- Rename `(*Agent).GetStatus` to `(*Agent).Status`
- Fix race condition during initialization w/ new method `primeInitAwait`
- Add 3 nonVoting nodes to integration tests